### PR TITLE
chore: bump for Capacitor 8

### DIFF
--- a/CapacitorVpnDetector.podspec
+++ b/CapacitorVpnDetector.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target = '14.0'
+  s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -3,14 +3,14 @@ import PackageDescription
 
 let package = Package(
     name: "CapacitorVpnDetector",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(
             name: "CapacitorVpnDetector",
             targets: ["VpnDetectorPluginPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
     ],
     targets: [
         .target(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-vpn-detector",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Capacitor plugin to detect VPN connections on Android and iOS.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -53,10 +53,10 @@
     "check-types": "npx tsc --noEmit"
   },
   "devDependencies": {
-    "@capacitor/android": "^7.4.2",
-    "@capacitor/core": "^7.4.2",
+    "@capacitor/android": "^8.0.0",
+    "@capacitor/core": "^8.0.0",
     "@capacitor/docgen": "^0.3.0",
-    "@capacitor/ios": "^7.4.2",
+    "@capacitor/ios": "^8.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
@@ -69,7 +69,7 @@
     "typescript": "~4.1.5"
   },
   "peerDependencies": {
-    "@capacitor/core": "^7.0.0"
+    "@capacitor/core": "^8.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",


### PR DESCRIPTION
- peerDependencies @capacitor/core ^7.0.0 → ^8.0.0
- devDependencies @capacitor/{android,core,ios} ^7.0.0 → ^8.0.0
- Package.swift: iOS .v14 → .v15, capacitor-swift-pm 7.0.0 → 8.0.0
- podspec: ios.deployment_target 14.0 → 15.0
- version 0.0.6 → 0.0.7